### PR TITLE
fixing room name

### DIFF
--- a/libs/app.bundle.js
+++ b/libs/app.bundle.js
@@ -1835,6 +1835,7 @@ UI.generateRoomName = function() {
         return roomName;
     var roomnode = null;
     var path = window.location.pathname;
+    path = path.substring(0, path.lastIndexOf("/"));      // Removing possible "/" char from the meeting room (happens with a fixed URL from apache. Ex: '/meeting/')
 
     // determinde the room node from the url
     // TODO: just the roomnode or the whole bare jid?


### PR DESCRIPTION
When you have an Apache server and you are getting an url with a trailing "/" (ex: '/meeting/') you could have troubles with the room name. Without this patch the room name may be "meeting/@your.own.server" and this could lead problems with your XMPP server