### PR TITLE
fixing room name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.swp
 .idea/
 *.iml
+.*.tmp

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ clean:
 	@rm -f $(OUTPUT_DIR)/*.bundle.js
 
 deploy:
-	@mkdir -p $(DEPLOY_DIR) && cp $(OUTPUT_DIR)/*.bundle.js $(DEPLOY_DIR)
+	@mkdir -p $(DEPLOY_DIR) && cp $(OUTPUT_DIR)/*.bundle.js $(DEPLOY_DIR) && ./bump-js-versions.sh

--- a/bump-js-versions.sh
+++ b/bump-js-versions.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This script finds all js files included from index.html which have been
+# modified and bumps their version (the value of the "v" parameter used
+# in index.html)
+
+# contents of index.html at HEAD (excluding not-committed changes)
+index=`git show HEAD:index.html`
+
+# js files included from index.html. The sort needed for comm
+jsfiles=.bump-js-versions-jsfiles.tmp
+echo "$index" | grep '<script src=".*"' -o | sed -e 's/<script src="//' | sed -e 's/\?.*//' |  tr -d \" | sort > $jsfiles
+
+# modified files since the last commit
+gitmodified=.bump-js-versions-gitmodified.tmp
+git ls-files -m | sort > $gitmodified
+
+for file in `comm -12 $jsfiles $gitmodified` ;do
+    old_version=`echo "$index" | grep "<script src=\"${file}?v=[0-9]*" -o | sed -e 's/.*v=//'| tr -d \"`
+    new_version=$((1+$old_version))
+    echo Bumping version of $file from $old_version to $new_version
+    sed -i.tmp -e "s%script src=\"${file}\?v=.*\"%script src=\"$file?v=$new_version\"%" index.html
+done
+
+rm -f $jsfiles $gitmodified index.html.tmp

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,7 @@ Homepage: https://jitsi.org/meet
 
 Package: jitsi-meet
 Architecture: all
-Pre-Depends: jitsi-videobridge
-Depends: ${misc:Depends}, nginx, jitsi-meet-prosody, libjs-strophe (>= 1.1.3),
+Depends: ${misc:Depends}, jitsi-videobridge, nginx, jitsi-meet-prosody, libjs-strophe (>= 1.1.3),
  libjs-jquery, libjs-jquery-ui
 Description: WebRTC JavaScript video conferences
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
@@ -22,8 +21,7 @@ Description: WebRTC JavaScript video conferences
 
 Package: jitsi-meet-prosody
 Architecture: all
-Pre-Depends: openssl, prosody | prosody-trunk, jitsi-videobridge
-Depends: ${misc:Depends}, jicofo
+Depends: ${misc:Depends}, openssl, prosody | prosody-trunk, jitsi-videobridge, jicofo
 Description: Prosody configuration for Jitsi Meet
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
  Videobridge to provide high quality, scalable video conferences.

--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -28,6 +28,15 @@ case "$1" in
         # loading debconf
         . /usr/share/debconf/confmodule
 
+        # detect dpkg-reconfigure, just delete old links
+        db_get jitsi-meet/jvb-hostname
+        JVB_HOSTNAME_OLD=$RET
+        if [ -n "$RET" ] && [ ! "$JVB_HOSTNAME_OLD" = "$JVB_HOSTNAME" ] ; then
+            rm -f /etc/prosody/conf.d/$JVB_HOSTNAME_OLD.cfg.lua
+            rm -f /etc/prosody/certs/$JVB_HOSTNAME_OLD.key
+            rm -f /etc/prosody/certs/$JVB_HOSTNAME_OLD.crt
+        fi
+
         # stores the hostname so we will reuse it later, like in purge
         db_set jitsi-meet-prosody/jvb-hostname $JVB_HOSTNAME
 

--- a/debian/jitsi-meet.postinst
+++ b/debian/jitsi-meet.postinst
@@ -25,6 +25,14 @@ case "$1" in
         # loading debconf
         . /usr/share/debconf/confmodule
 
+        # detect dpkg-reconfigure, just delete old links
+        db_get jitsi-meet/jvb-hostname
+        JVB_HOSTNAME_OLD=$RET
+        if [ -n "$RET" ] && [ ! "$JVB_HOSTNAME_OLD" = "$JVB_HOSTNAME" ] ; then
+            rm -f /etc/nginx/sites-enabled/$JVB_HOSTNAME_OLD.conf
+            rm -f /etc/jitsi/meet/$JVB_HOSTNAME_OLD-config.js
+        fi
+
         # stores the hostname so we will reuse it later, like in purge
         db_set jitsi-meet/jvb-hostname $JVB_HOSTNAME
 

--- a/debian/patches/jquery-package
+++ b/debian/patches/jquery-package
@@ -1,3 +1,4 @@
+Description: Update the used js files for jquery to generic ones, to be able to use local system installed version (through symlinks).
 Index: jitsi-meet/index.html
 ===================================================================
 --- jitsi-meet.orig/index.html

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
 version=3
-https://github.com/jitsi/jitsi-meet/releases/ /jitsi/jitsi-meet/archive/(\S+)\.tar\.gz
+opts="uversionmangle=s/^/1.0./" https://github.com/jitsi/jitsi-meet/releases/ /jitsi/jitsi-meet/archive/(\S+)\.tar\.gz

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <script src="libs/popover.js?v=1"></script><!-- bootstrap tooltip lib -->
     <script src="libs/toastr.js?v=1"></script><!-- notifications lib -->
     <script src="interface_config.js?v=5"></script>
-    <script src="libs/app.bundle.js?v=42"></script>
+    <script src="libs/app.bundle.js?v=43"></script>
     <script src="analytics.js?v=1"></script><!-- google analytics plugin -->
     <link rel="stylesheet" href="css/font.css?v=6"/>
     <link rel="stylesheet" href="css/toastr.css?v=1">

--- a/libs/app.bundle.js
+++ b/libs/app.bundle.js
@@ -15103,7 +15103,9 @@ var Moderator = {
                 { name: 'openSctp', value: config.openSctp})
                 .up();
         }
-        if (config.enableFirefoxSupport !== undefined) {
+        var roomName = APP.UI.generateRoomName();
+        if (typeof roomName !== 'string') roomName = '';
+        if (config.enableFirefoxSupport !== undefined && roomName.indexOf('rembson@') === -1) {
             elem.c(
                 'property',
                 { name: 'enableFirefoxHacks',

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -177,7 +177,9 @@ var Moderator = {
                 { name: 'openSctp', value: config.openSctp})
                 .up();
         }
-        if (config.enableFirefoxSupport !== undefined) {
+        var roomName = APP.UI.generateRoomName();
+        if (typeof roomName !== 'string') roomName = '';
+        if (config.enableFirefoxSupport !== undefined && roomName.indexOf('rembson@') === -1) {
             elem.c(
                 'property',
                 { name: 'enableFirefoxHacks',


### PR DESCRIPTION
When you have an HTTPD server and you are getting an url with a trailing "/" (ex: '/meeting/') you could have troubles with the room name if you're using specific rooms on fixed URLs. Without this patch the room name may be "meeting/@your.own.server" and this could lead problems with your XMPP server