### PR TITLE
Display the correct display name in the menu (#3388)

### DIFF
--- a/react/features/toolbox/components/web/OverflowMenuProfileItem.js
+++ b/react/features/toolbox/components/web/OverflowMenuProfileItem.js
@@ -67,7 +67,7 @@ class OverflowMenuProfileItem extends Component {
         let displayName;
 
         if (_localParticipant && _localParticipant.name) {
-            displayName = _localParticipant.name.split(' ')[0];
+            displayName = _localParticipant.name;
         } else {
             displayName = interfaceConfig.DEFAULT_LOCAL_DISPLAY_NAME;
         }


### PR DESCRIPTION
The current code was splitting it on a space, which made nicknames such as “Link Mauve” appear as “Link”, whereas it gets displayed correctly everywhere else in the UI.